### PR TITLE
fix(malloc_free): remove vmlinux.h dependency

### DIFF
--- a/appsdk_builder
+++ b/appsdk_builder
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+if [ "$1" = "clean" ];then
+	docker run --rm -it -v $PWD:/work/  joukan/rpi4-appsdk:latest cargo_clean
+	exit
+fi
+
+docker run --rm -it -v $PWD:/work/  joukan/rpi4-appsdk:latest cargo_build $*


### PR DESCRIPTION
This PR fixes issue #5 by removing the dependency on `vmlinux.h` in the `malloc_free` BPF program. This should allow the program to be loaded on kernels without BTF information.