### PR TITLE
feat: Improve libc.so.6 path discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "jtracing"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "byteorder",
  "cc",


### PR DESCRIPTION
This PR addresses issue #19 by improving the discovery of `libc.so.6` path for the `malloc_free` tool.

Changes include:
- Automatically attempting to discover `libc.so.6` in common locations (`/lib/x86_64-linux-gnu/libc.so.6`, `/usr/lib/libc.so.6`, `/lib/libc.so.6`).
- Providing a more informative error message if `libc.so.6` is not found, guiding the user to specify the path using `--libpath`.

This enhances the tool's portability and user-friendliness across different Linux distributions.

close #19